### PR TITLE
introduce gatekeeper and the signing secret env to verify requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Example:
 TOKEN=xoxp-12345678-87654321-10011001-3x4mp13
 ```
 
+### `SECRET`
+
+The Slack app's signing secret is required.  
+Slack provides the app's signing secret on the **Base Information** page of your app.
+
 ### `[PORT=3000]`
 
 Pass in an integer to use a custom port.  

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser')
 const Cron = require('cron').CronJob
 const environment = require('./lib/environment')
 const handlers = require('./lib/handlers')
+const gatekeeper = require('./lib/gatekeeper')
 require('dotenv').config()
 
 environment.validate()
@@ -14,8 +15,8 @@ app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
 
 app.get('/', (req, res) => res.json({ status: 'ok' }))
-app.post('/', handlers.promptLocations)
-app.post('/folks', handlers.feedback)
+app.post('/', gatekeeper, handlers.promptLocations)
+app.post('/folks', gatekeeper, handlers.feedback)
 
 Object.keys(environment.timezones).forEach(timezone => {
   const cities = environment.timezones[timezone].map(x => x.toLowerCase())

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -2,6 +2,7 @@ class Environment {
   constructor () {
     this.locationsRegExp = /^(#[a-z_-]*\/[a-z_-]*:[a-z_-\s0-9]*(,[a-z_-\s0-9]*)*)+$/ig
     this.token = process.env.TOKEN
+    this.secret = process.env.SECRET
     this.port = process.env.PORT || 3000
     this.locations = this.extractLocations(process.env.LOCATIONS)
     this.timezones = this.extractTimezones(process.env.LOCATIONS)
@@ -18,6 +19,10 @@ class Environment {
 
     if (!process.env.TOKEN) {
       throw Error('Please provide the related Slack OAuth Token as `TOKEN`.')
+    }
+
+    if (!process.env.SECRET) {
+      throw Error('Please provide the related Slack Signing Secret as `SECRET`.')
     }
   }
 

--- a/lib/gatekeeper.js
+++ b/lib/gatekeeper.js
@@ -1,0 +1,34 @@
+const qs = require('querystring')
+const crypto = require('crypto')
+const environment = require('./environment')
+
+const denyAccess = (res) => res.status(401).json({
+  statusCode: 401,
+  error: 'Unauthorized'
+})
+
+module.exports = (req, res, next) => {
+  const {
+    'x-slack-signature': signature,
+    'x-slack-request-timestamp': timestamp
+  } = req.headers
+
+  const timestampMs = timestamp * 1000
+  const timeDelta = Date.now() - timestampMs
+  const deltaThreshold = 1000 * 60 * 5
+
+  if (timeDelta > deltaThreshold) {
+    return denyAccess(res)
+  }
+
+  const key = environment.secret
+  const bodyParams = qs.stringify(req.body)
+  const toSign = `v0:${timestamp}:${bodyParams}`
+  const hash = `v0=${crypto.createHmac('sha256', key).update(toSign).digest('hex')}`
+
+  if (hash !== signature) {
+    return denyAccess(res)
+  }
+
+  next()
+}

--- a/now.json
+++ b/now.json
@@ -2,6 +2,7 @@
   "type": "npm",
   "env": [
     "TOKEN",
+    "SECRET",
     "LOCATIONS"
   ]
 }


### PR DESCRIPTION
Related to #1.

It uses [slack's proposal to verify requests](https://api.slack.com/docs/verifying-requests-from-slack) by using:

1) `req.body`, slack/request-specific headers and a signing secret
2) replay attack prevention

For this purpose it is necessary to set additionally the `SECRET` env.