### PR TITLE
Introduce Group Message instead of broadcasting single DMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ PORT=8080
 
 ### Permissions
 - `chat:write:bot`
+- `channels:write`
+- `groups:write`
+- `mpim:write`
+- `im:write`
 - `commands`
 
 ## Development

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,31 +1,19 @@
-const qs = require('querystring')
-const axios = require('axios')
 const storage = require('./storage')
 const environment = require('./environment')
 const postman = require('./postman')
-
-const notify = (userId, matches) => {
-  const opts = {
-    token: environment.token,
-    channel: userId,
-    icon_emoji: ':knife_fork_plate:',
-    username: 'erna',
-    text: postman.hooray(matches)
-  }
-
-  if (!matches.length) {
-    opts.text = postman.nope
-  }
-
-  axios.get(`https://slack.com/api/chat.postMessage?${qs.stringify(opts)}`)
-    .then(({ data }) => console.log(data))
-    .catch(console.error)
-}
+const notifier = require('./notifier')
 
 const signup = (res, key, value) => {
   const result = storage.push(key, value)
 
   return res.json(result ? postman.confirmation : postman.duplicate)
+}
+
+const confirm = (payload, res) => {
+  const location = payload.actions[0].selected_options[0].value
+  const userId = payload.user.id
+
+  return signup(res, location, userId)
 }
 
 const promptLocations = (req, res) => {
@@ -46,26 +34,16 @@ const feedback = (req, res) => {
 
   switch (action) {
     case 'location':
-      confirm(payload, res)
-      break
+      return confirm(payload, res)
     case 'cancel':
-      res.json(postman.cancel)
-      break
+      return res.json(postman.cancel)
   }
 }
 
-const confirm = (payload, res) => {
-  const location = payload.actions[0].selected_options[0].value
-  const userId = payload.user.id
-
-  return signup(res, location, userId)
-}
-
 const match = (cities) => () => {
-  storage.match(cities).forEach((match) => {
-    match.forEach((userId) => notify(userId, match.filter(x => x !== userId)))
+  storage.match(cities).forEach(function (match) {
+    notifier.trigger(match)
   })
-
   storage.purge(cities)
 }
 

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -1,0 +1,62 @@
+const qs = require('querystring')
+const axios = require('axios')
+const environment = require('./environment')
+const postman = require('./postman')
+
+class Notifier {
+  constructor () {
+    this.apiUrl = 'https://slack.com/api'
+    this.icon = ':knife_fork_plate:'
+    this.username = 'erna'
+  }
+
+  request (method, endpoint, opts) {
+    const query = Object.assign({ token: environment.token }, opts)
+    const requestUrl = `${this.apiUrl}/${endpoint}?${qs.stringify(query)}`
+
+    return axios[method](requestUrl)
+      .then(({ data }) => console.log(data) || data)
+      .catch(console.error)
+  }
+
+  open (users) {
+    return this.request('post', 'conversations.open', { users: users.join(',') })
+  }
+
+  send (channel, text) {
+    return this.request('post', 'chat.postMessage', {
+      token: environment.token,
+      icon_emoji: this.icon,
+      username: this.username,
+      channel,
+      text
+    })
+  }
+
+  reject (userId) {
+    return this.send(userId, postman.nope)
+  }
+
+  broadcast (match) {
+    match.forEach((userId) => this.send(
+      userId,
+      postman.hooray(match.filter(x => x !== userId))
+    ))
+  }
+
+  trigger (match) {
+    if (match.length === 1) {
+      return this.reject(match[0])
+    }
+
+    return this.open(match).then(({ ok, channel }) => {
+      if (!ok) {
+        return this.broadcast(match)
+      }
+
+      return this.send(channel.id, postman.hoorayAll(match))
+    })
+  }
+}
+
+module.exports = new Notifier()

--- a/lib/postman.js
+++ b/lib/postman.js
@@ -60,7 +60,10 @@ class Postman {
   }
 
   linkMatches (matches) {
-    return matches.map(x => `<@${x}>`).join(' & ')
+    const links = matches.map(x => `<@${x}>`)
+    const last = links.pop()
+
+    return [links.join(', '), last].join(' & ')
   }
 
   get confirmation () {
@@ -86,6 +89,16 @@ class Postman {
       `Your lunch date: ${links}.\nGet in touch and enjoy your lunch! 😋`,
       `As promised, I have a lunch date for you! 🎉\nGet in touch with ${links}.`,
       `Surely you have waited already for your date! 😉\n Drop ${links} a line and enjoy your lunch.`
+    ])
+  }
+
+  hoorayAll (matches) {
+    const links = this.linkMatches(matches)
+
+    return this.random([
+      `Hi ${links} – you have been matched for a lunch date!\nGet in touch with each other and enjoy your lunch! 😋`,
+      `Hiya ${links}!\nAs promised, I have organized a lunch date! 🎉\nSettle the details and enjoy your lunch!`,
+      `Surely you have waited already for your date! 😉\nWell you – ${links} – have matched.\nI hope you're looking forward to meeting each other and enjoying your lunch.`
     ])
   }
 }


### PR DESCRIPTION
Related to #3.

This implementation tries to open a DM for a group of users (match partners) instead of broadcasting single DMs. This feature aims to improve the UX.

The current behavior is kept as fallback if it is not possible to create group.