### PR TITLE
Enable restoring the current signups of another instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 1. [Introduction](#introduction)
 1. [Configuration](#configuration)
+1. [Subcommands](#subcommands)
 1. [Endpoints and Permissions](#endpoints-and-permissions)
 1. [Setup Slack App ⇗](docs/slack-setup.md)
 1. [Development](#development)
@@ -82,6 +83,9 @@ Example:
 ```sh
 PORT=8080
 ```
+
+## Subcommands
+- `restore [url]` – Restore the state of another instance as long as both use the same `SECRET`
 
 ## Endpoints and Permissions
 ### Endpoints

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ PORT=8080
 
 ### Permissions
 - `chat:write:bot`
+- `channels:write`
+- `groups:write`
+- `mpim:write`
+- `im:write`
 - `commands`
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ PORT=8080
 ## Endpoints and Permissions
 ### Endpoints
 - `GET /` – Health Check
-- `POST /` – Slash Command
-- `POST /folks` – Interactive Components
+- `GET /locations` – List of all locations and their current sign-ups
+- `POST /commands` – Slash Command
+- `POST /actions` – Interactive Components
 
 ### Permissions
 - `chat:write:bot`

--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ PORT=8080
 
 ### Permissions
 - `chat:write:bot`
-- `channels:write`
-- `groups:write`
 - `mpim:write`
 - `im:write`
 - `commands`

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser')
 const Cron = require('cron').CronJob
 const environment = require('./lib/environment')
 const handlers = require('./lib/handlers')
+const storage = require('./lib/storage')
 const gatekeeper = require('./lib/gatekeeper')
 require('dotenv').config()
 
@@ -10,13 +11,17 @@ environment.validate()
 
 const app = express()
 const crons = {}
+const rawBodySaver = (req, res, buf, encoding) => {
+  req.rawBody = buf && buf.length ? buf.toString(encoding || 'utf8') : undefined
+}
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(bodyParser.json({ verify: rawBodySaver }))
+app.use(bodyParser.urlencoded({ extended: true, verify: rawBodySaver }))
 
 app.get('/', (req, res) => res.json({ status: 'ok' }))
-app.post('/', gatekeeper, handlers.promptLocations)
-app.post('/folks', gatekeeper, handlers.feedback)
+app.get('/locations', gatekeeper.lock, (req, res) => storage.list('locations', res))
+app.post('/commands', gatekeeper.lock, handlers.commands)
+app.post('/actions', gatekeeper.lock, handlers.actions)
 
 Object.keys(environment.timezones).forEach(timezone => {
   const cities = environment.timezones[timezone].map(x => x.toLowerCase())

--- a/lib/gatekeeper.js
+++ b/lib/gatekeeper.js
@@ -1,4 +1,3 @@
-const qs = require('querystring')
 const crypto = require('crypto')
 const environment = require('./environment')
 
@@ -7,7 +6,14 @@ const denyAccess = (res) => res.status(401).json({
   error: 'Unauthorized'
 })
 
-module.exports = (req, res, next) => {
+const hash = (timestamp, body) => {
+  const key = environment.secret
+  const toSign = `v0:${timestamp}:${body}`
+
+  return `v0=${crypto.createHmac('sha256', key).update(toSign).digest('hex')}`
+}
+
+const lock = (req, res, next) => {
   const {
     'x-slack-signature': signature,
     'x-slack-request-timestamp': timestamp
@@ -21,14 +27,14 @@ module.exports = (req, res, next) => {
     return denyAccess(res)
   }
 
-  const key = environment.secret
-  const bodyParams = qs.stringify(req.body)
-  const toSign = `v0:${timestamp}:${bodyParams}`
-  const hash = `v0=${crypto.createHmac('sha256', key).update(toSign).digest('hex')}`
-
-  if (hash !== signature) {
+  if (hash(timestamp, req.rawBody) !== signature) {
     return denyAccess(res)
   }
 
   next()
+}
+
+module.exports = {
+  lock,
+  hash
 }

--- a/lib/gatekeeper.js
+++ b/lib/gatekeeper.js
@@ -6,7 +6,7 @@ const denyAccess = (res) => res.status(401).json({
   error: 'Unauthorized'
 })
 
-const hash = (timestamp, body) => {
+const hmac = (timestamp, body) => {
   const key = environment.secret
   const toSign = `v0:${timestamp}:${body}`
 
@@ -27,7 +27,7 @@ const lock = (req, res, next) => {
     return denyAccess(res)
   }
 
-  if (hash(timestamp, req.rawBody) !== signature) {
+  if (hmac(timestamp, req.rawBody) !== signature) {
     return denyAccess(res)
   }
 
@@ -36,5 +36,5 @@ const lock = (req, res, next) => {
 
 module.exports = {
   lock,
-  hash
+  hmac
 }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,31 +1,19 @@
-const qs = require('querystring')
-const axios = require('axios')
 const storage = require('./storage')
 const environment = require('./environment')
 const postman = require('./postman')
-
-const notify = (userId, matches) => {
-  const opts = {
-    token: environment.token,
-    channel: userId,
-    icon_emoji: ':knife_fork_plate:',
-    username: 'erna',
-    text: postman.hooray(matches)
-  }
-
-  if (!matches.length) {
-    opts.text = postman.nope
-  }
-
-  axios.get(`https://slack.com/api/chat.postMessage?${qs.stringify(opts)}`)
-    .then(({ data }) => console.log(data))
-    .catch(console.error)
-}
+const notifier = require('./notifier')
 
 const signup = (res, key, value) => {
   const result = storage.push(key, value)
 
   return res.json(result ? postman.confirmation : postman.duplicate)
+}
+
+const confirm = (payload, res) => {
+  const location = payload.actions[0].selected_options[0].value
+  const userId = payload.user.id
+
+  return signup(res, location, userId)
 }
 
 const promptLocations = (req, res) => {
@@ -46,26 +34,16 @@ const feedback = (req, res) => {
 
   switch (action) {
     case 'location':
-      confirm(payload, res)
-      break
+      return confirm(payload, res)
     case 'cancel':
-      res.json(postman.cancel)
-      break
+      return res.json(postman.cancel)
   }
 }
 
-const confirm = (payload, res) => {
-  const location = payload.actions[0].selected_options[0].value
-  const userId = payload.user.id
-
-  return signup(res, location, userId)
-}
-
 const match = (cities) => () => {
-  storage.match(cities).forEach((match) => {
-    match.forEach((userId) => notify(userId, match.filter(x => x !== userId)))
+  storage.match(cities).forEach(function (match) {
+    notifier.trigger(match)
   })
-
   storage.purge(cities)
 }
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -16,6 +16,17 @@ const confirm = (payload, res) => {
   return signup(res, location, userId)
 }
 
+const commands = (req, res) => {
+  const [subcmd, ...params] = req.body.text.split(' ')
+
+  switch (subcmd) {
+    case 'replay':
+      return storage.replay(req, res, params)
+    default:
+      return promptLocations(req, res, params)
+  }
+}
+
 const promptLocations = (req, res) => {
   if (storage.has(req.body.user_id)) {
     return res.json(postman.duplicate)
@@ -28,7 +39,7 @@ const promptLocations = (req, res) => {
   return res.json(postman.locations)
 }
 
-const feedback = (req, res) => {
+const actions = (req, res) => {
   const payload = JSON.parse(req.body.payload)
   const action = payload.actions[0].name
 
@@ -48,7 +59,7 @@ const match = (cities) => () => {
 }
 
 module.exports = {
-  promptLocations,
-  feedback,
+  commands,
+  actions,
   match
 }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -9,13 +9,6 @@ const signup = (res, key, value) => {
   return res.json(result ? postman.confirmation : postman.duplicate)
 }
 
-const confirm = (payload, res) => {
-  const location = payload.actions[0].selected_options[0].value
-  const userId = payload.user.id
-
-  return signup(res, location, userId)
-}
-
 const commands = (req, res) => {
   const [subcmd, ...params] = req.body.text.split(' ')
 
@@ -23,20 +16,16 @@ const commands = (req, res) => {
     case 'restore':
       return storage.restore(req, res, params)
     default:
-      return promptLocations(req, res, params)
-  }
-}
+      if (storage.has(req.body.user_id)) {
+        return res.json(postman.duplicate)
+      }
 
-const promptLocations = (req, res) => {
-  if (storage.has(req.body.user_id)) {
-    return res.json(postman.duplicate)
-  }
+      if (environment.locations.length === 1) {
+        return signup(res, environment.locations[0], req.body.user_id)
+      }
 
-  if (environment.locations.length === 1) {
-    return signup(res, environment.locations[0], req.body.user_id)
+      return res.json(postman.locations)
   }
-
-  return res.json(postman.locations)
 }
 
 const actions = (req, res) => {
@@ -45,7 +34,10 @@ const actions = (req, res) => {
 
   switch (action) {
     case 'location':
-      return confirm(payload, res)
+      const location = payload.actions[0].selected_options[0].value
+      const userId = payload.user.id
+
+      return signup(res, location, userId)
     case 'cancel':
       return res.json(postman.cancel)
   }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -20,8 +20,8 @@ const commands = (req, res) => {
   const [subcmd, ...params] = req.body.text.split(' ')
 
   switch (subcmd) {
-    case 'replay':
-      return storage.replay(req, res, params)
+    case 'restore':
+      return storage.restore(req, res, params)
     default:
       return promptLocations(req, res, params)
   }

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -1,0 +1,62 @@
+const qs = require('querystring')
+const axios = require('axios')
+const environment = require('./environment')
+const postman = require('./postman')
+
+class Notifier {
+  constructor () {
+    this.apiUrl = 'https://slack.com/api'
+    this.icon = ':knife_fork_plate:'
+    this.username = 'erna'
+  }
+
+  request (method, endpoint, opts) {
+    const query = Object.assign({ token: environment.token }, opts)
+    const requestUrl = `${this.apiUrl}/${endpoint}?${qs.stringify(query)}`
+
+    return axios[method](requestUrl)
+      .then(({ data }) => console.log(data) || data)
+      .catch(console.error)
+  }
+
+  open (users) {
+    return this.request('post', 'conversations.open', { users: users.join(',') })
+  }
+
+  send (channel, text) {
+    return this.request('post', 'chat.postMessage', {
+      token: environment.token,
+      icon_emoji: this.icon,
+      username: this.username,
+      channel,
+      text
+    })
+  }
+
+  reject (userId) {
+    return this.send(userId, postman.nope)
+  }
+
+  broadcast (match) {
+    match.forEach((userId) => this.send(
+      userId,
+      postman.hooray(match.filter(x => x !== userId))
+    ))
+  }
+
+  trigger (match) {
+    if (match.length === 1) {
+      return this.reject(match[0])
+    }
+
+    return this.open(match).then(({ ok, channel }) => {
+      if (!ok) {
+        return this.broadcast(match)
+      }
+
+      return this.send(channel.id, postman.hoorayAll(match))
+    })
+  }
+}
+
+module.exports = new Notifier()

--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -15,17 +15,16 @@ class Notifier {
     const requestUrl = `${this.apiUrl}/${endpoint}?${qs.stringify(query)}`
 
     return axios[method](requestUrl)
-      .then(({ data }) => console.log(data) || data)
+      .then(({ data }) => (!data.ok && console.log(data)) || data)
       .catch(console.error)
   }
 
-  open (users) {
+  openConversation (users) {
     return this.request('post', 'conversations.open', { users: users.join(',') })
   }
 
   send (channel, text) {
     return this.request('post', 'chat.postMessage', {
-      token: environment.token,
       icon_emoji: this.icon,
       username: this.username,
       channel,
@@ -49,7 +48,7 @@ class Notifier {
       return this.reject(match[0])
     }
 
-    return this.open(match).then(({ ok, channel }) => {
+    return this.openConversation(match).then(({ ok, channel }) => {
       if (!ok) {
         return this.broadcast(match)
       }

--- a/lib/postman.js
+++ b/lib/postman.js
@@ -60,7 +60,10 @@ class Postman {
   }
 
   linkMatches (matches) {
-    return matches.map(x => `<@${x}>`).join(' & ')
+    const links = matches.map(x => `<@${x}>`)
+    const last = links.pop()
+
+    return [links.join(', '), last].join(' & ')
   }
 
   get confirmation () {
@@ -86,6 +89,16 @@ class Postman {
       `Your lunch date: ${links}.\nGet in touch and enjoy your lunch! 😋`,
       `As promised, I have a lunch date for you! 🎉\nGet in touch with ${links}.`,
       `Surely you have waited already for your date! 😉\n Drop ${links} a line and enjoy your lunch.`
+    ])
+  }
+
+  hoorayAll (matches) {
+    const links = this.linkMatches(matches)
+
+    return this.random([
+      `Hi ${links} – you have been matched for a lunch date!\nGet in touch with each other and enjoy your lunch! 😋`,
+      `Hiya ${links}!\nAs promised, I have organized a lunch date! 🎉\nSettle the details and enjoy your lunch!`,
+      `Surely you have waited already for your date! 😉\nWell you – ${links} – have matched.\nI hope you're looking forward to meeting each other and enjoying your lunch.`
     ])
   }
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -73,11 +73,11 @@ class Storage {
     return res.json(this[prop])
   }
 
-  replay (req, res, params) {
-    const replayUrl = params[0]
+  restore (req, res, params) {
+    const restoreUrl = params[0]
     const timestamp = parseInt(Date.now() / 1000, 10)
 
-    axios.get(`${replayUrl}/locations`, {
+    axios.get(`${restoreUrl}/locations`, {
       headers: {
         'x-slack-signature': gatekeeper.hash(timestamp),
         'x-slack-request-timestamp': timestamp * 1.1
@@ -87,7 +87,7 @@ class Storage {
         this.locations[city] = [...this.locations[city] || [], ...data[city]]
       })
 
-      return res.json({ text: 'Successfully replayed the data.' })
+      return res.json({ text: 'Successfully restored the data.' })
     }).catch((error) => {
       console.error(error.message)
       return res.json({ text: 'Sorry, replay failed!' })

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -79,7 +79,7 @@ class Storage {
 
     axios.get(`${restoreUrl}/locations`, {
       headers: {
-        'x-slack-signature': gatekeeper.hash(timestamp),
+        'x-slack-signature': gatekeeper.hmac(timestamp),
         'x-slack-request-timestamp': timestamp * 1.1
       }
     }).then(({ data }) => {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,3 +1,6 @@
+const axios = require('axios')
+const gatekeeper = require('./gatekeeper')
+
 class Storage {
   constructor () {
     this.locations = {}
@@ -63,6 +66,31 @@ class Storage {
   purge (cities) {
     cities.forEach((city) => {
       delete this.locations[city]
+    })
+  }
+
+  list (prop, res) {
+    return res.json(this[prop])
+  }
+
+  replay (req, res, params) {
+    const replayUrl = params[0]
+    const timestamp = parseInt(Date.now() / 1000, 10)
+
+    axios.get(`${replayUrl}/locations`, {
+      headers: {
+        'x-slack-signature': gatekeeper.hash(timestamp),
+        'x-slack-request-timestamp': timestamp * 1.1
+      }
+    }).then(({ data }) => {
+      Object.keys(data).forEach((city) => {
+        this.locations[city] = [...this.locations[city] || [], ...data[city]]
+      })
+
+      return res.json({ text: 'Successfully replayed the data.' })
+    }).catch((error) => {
+      console.error(error.message)
+      return res.json({ text: 'Sorry, replay failed!' })
     })
   }
 }


### PR DESCRIPTION
Related to #5 

To avoid interruptions while deploying a new version of the app, this feature adds a `restore` subcommand which allows to restore the state of another instance.

**Requirement:**
Both instances have to use the same `SECRET`.
This ensures that just authorized instances can access each other.

simply run `/[command] restore [url-of-old-instance]`
