### PR TITLE
add ENV to change desired match size

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ Example:
 PORT=8080
 ```
 
+### `[MATCH_SIZE=2]`
+
+Pass in an integer as desired match size.  
+Actual size may differ because of an odd number of members per location.
+
+```sh
+MATCH_SIZE=4
+```
+
 ## Endpoints and Permissions
 ### Endpoints
 - `GET /` – Health Check

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -4,6 +4,7 @@ class Environment {
     this.token = process.env.TOKEN
     this.secret = process.env.SECRET
     this.port = process.env.PORT || 3000
+    this.matchSize = parseInt(process.env.MATCH_SIZE || '2', 10)
     this.locations = this.extractLocations(process.env.LOCATIONS)
     this.timezones = this.extractTimezones(process.env.LOCATIONS)
   }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,3 +1,5 @@
+const environment = require('./environment')
+
 class Storage {
   constructor () {
     this.locations = {}
@@ -30,7 +32,7 @@ class Storage {
     let tempList
     let index = 0
     const result = []
-    const size = 2
+    const size = environment.matchSize
     const length = list.length
 
     if (length < 2) {


### PR DESCRIPTION
Related to #7.
Pass `MATCH_SIZE` to define the desired match size.